### PR TITLE
Adds Heredoc to FormattingContext

### DIFF
--- a/native/src/parser_state.rs
+++ b/native/src/parser_state.rs
@@ -29,6 +29,7 @@ pub enum FormattingContext {
     Def,
     CurlyBlock,
     ArgsList,
+    Heredoc
 }
 
 #[derive(Clone, Copy)]


### PR DESCRIPTION
Hello Penelope, 

After the oxidize merge, I wanted to give rubyfmt a try but unfortunately the compilation of the Rust packages failed with:
```
error[E0599]: no variant or associated item named `Heredoc` found for type `parser_state::FormattingContext` in the current scope
   --> src/parser_state.rs:146:71
    |
24  | pub enum FormattingContext {
    | -------------------------- variant or associated item `Heredoc` not found here
...
146 |         if self.formatting_context.last() != Some(&FormattingContext::Heredoc) {
    |                                                                       ^^^^^^^ variant or associated item not found in `parser_state::FormattingContext`

error[E0599]: no variant or associated item named `Heredoc` found for type `parser_state::FormattingContext` in the current scope
   --> src/parser_state.rs:501:61
    |
24  | pub enum FormattingContext {
    | -------------------------- variant or associated item `Heredoc` not found here
...
501 |             self.with_formatting_context(FormattingContext::Heredoc, |ps| {
    |                                                             ^^^^^^^ variant or associated item not found in `parser_state::FormattingContext`

error: aborting due to 2 previous errors

For more information about this error, try `rustc --explain E0599`.
error: could not compile `native`.
```

TBH I have little experience with Rust and I basically guessed this fix based on the compiler output. 

Thanks,

Willian

ps. keep up the good work! this is an exciting project!

