### PR TITLE
Operate directly on the ripper output without JSON parsing

### DIFF
--- a/ext/rubyfmt.c
+++ b/ext/rubyfmt.c
@@ -1,10 +1,15 @@
 #include "rubyfmt.h"
 
-extern int64_t format_sexp_tree_to_stdout(ruby_string_pointer buf, ruby_string_pointer tree);
-extern int64_t format_sexp_tree_to_file(
-     ruby_string_pointer filename,
-     ruby_string_pointer buf,
-     ruby_string_pointer tree
+extern void format_sexp_tree_to_stdout(
+    VALUE runtime_error,
+    ruby_string_pointer buf,
+    VALUE tree
+);
+extern void format_sexp_tree_to_file(
+    VALUE runtime_error,
+    ruby_string_pointer filename,
+    ruby_string_pointer buf,
+    VALUE tree
 );
 
 VALUE rubyfmt_rb_module_rubyfmt = Qnil;
@@ -14,30 +19,18 @@ ruby_string_pointer ruby_string_pointer_from_value(VALUE string) {
     return ret;
 }
 
-VALUE rubyfmt_rb_format_to_stdout(VALUE _mod, VALUE file_buffer, VALUE tree_json) {
+VALUE rubyfmt_rb_format_to_stdout(VALUE _mod, VALUE file_buffer, VALUE tree) {
     ruby_string_pointer file = ruby_string_pointer_from_value(file_buffer);
-    ruby_string_pointer tree = ruby_string_pointer_from_value(tree_json);
 
-    int64_t status = format_sexp_tree_to_stdout(file, tree);
-
-    if (status != 0) {
-        rb_raise(rb_eRuntimeError, "Error code %lli", status);
-    }
-
+    format_sexp_tree_to_stdout(rb_eRuntimeError, file, tree);
     return Qnil;
 }
 
-VALUE rubyfmt_rb_format_to_file(VALUE _mod, VALUE filename, VALUE file_buffer, VALUE tree_json) {
+VALUE rubyfmt_rb_format_to_file(VALUE _mod, VALUE filename, VALUE file_buffer, VALUE tree) {
     ruby_string_pointer fn_p = ruby_string_pointer_from_value(filename);
     ruby_string_pointer buf = ruby_string_pointer_from_value(file_buffer);
-    ruby_string_pointer tree = ruby_string_pointer_from_value(tree_json);
 
-    int64_t status = format_sexp_tree_to_file(fn_p, buf, tree);
-
-    if (status != 0) {
-        rb_raise(rb_eRuntimeError, "Error code %lli", status);
-    }
-
+    format_sexp_tree_to_file(rb_eRuntimeError, fn_p, buf, tree);
     return Qnil;
 }
 

--- a/ext/rubyfmt.c
+++ b/ext/rubyfmt.c
@@ -1,12 +1,7 @@
 #include "rubyfmt.h"
 
-extern void format_sexp_tree_to_stdout(
-    VALUE runtime_error,
-    ruby_string_pointer buf,
-    VALUE tree
-);
+extern void format_sexp_tree_to_stdout(ruby_string_pointer buf, VALUE tree);
 extern void format_sexp_tree_to_file(
-    VALUE runtime_error,
     ruby_string_pointer filename,
     ruby_string_pointer buf,
     VALUE tree
@@ -22,7 +17,7 @@ ruby_string_pointer ruby_string_pointer_from_value(VALUE string) {
 VALUE rubyfmt_rb_format_to_stdout(VALUE _mod, VALUE file_buffer, VALUE tree) {
     ruby_string_pointer file = ruby_string_pointer_from_value(file_buffer);
 
-    format_sexp_tree_to_stdout(rb_eRuntimeError, file, tree);
+    format_sexp_tree_to_stdout(file, tree);
     return Qnil;
 }
 
@@ -30,8 +25,28 @@ VALUE rubyfmt_rb_format_to_file(VALUE _mod, VALUE filename, VALUE file_buffer, V
     ruby_string_pointer fn_p = ruby_string_pointer_from_value(filename);
     ruby_string_pointer buf = ruby_string_pointer_from_value(file_buffer);
 
-    format_sexp_tree_to_file(rb_eRuntimeError, fn_p, buf, tree);
+    format_sexp_tree_to_file(fn_p, buf, tree);
     return Qnil;
+}
+
+char *rubyfmt_rstring_ptr(VALUE s) {
+  return RSTRING_PTR(s);
+}
+
+long rubyfmt_rstring_len(VALUE s) {
+  return RSTRING_LEN(s);
+}
+
+enum ruby_value_type rubyfmt_rb_type(VALUE v) {
+  return rb_type(v);
+}
+
+long long rubyfmt_rb_num2ll(VALUE v) {
+  return RB_NUM2LL(v);
+}
+
+long rubyfmt_rb_ary_len(VALUE v) {
+  return rb_array_len(v);
 }
 
 void Init_rubyfmt() {

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -96,6 +96,7 @@ dependencies = [
  "jemallocator 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rutie 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -136,6 +137,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "rustc-demangle"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rutie"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "ryu"
@@ -212,6 +222,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum regex 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "322cf97724bea3ee221b78fe25ac9c46114ebb51747ad5babd51a2fc6a8235a8"
 "checksum regex-syntax 0.6.16 (registry+https://github.com/rust-lang/crates.io-index)" = "1132f845907680735a84409c3bebc64d1364a5683ffbce899550cd09d5eaefc1"
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
+"checksum rutie 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "99a4174504679e66c524ffd839767eeca900d8c2e332ecf8bc6b9f15a5b8e5b1"
 "checksum ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c92464b447c0ee8c4fb3824ecc8383b81717b9f1e74ba2e72540aef7b9f82997"
 "checksum serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)" = "d46b3dfedb19360a74316866cef04687cd4d6a70df8e6a506c63512790769b72"
 "checksum serde_derive 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)" = "c22a0820adfe2f257b098714323563dd06426502abbbce4f51b72ef544c5027f"

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -95,8 +95,8 @@ dependencies = [
  "bytecount 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jemallocator 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "rutie 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -137,15 +137,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "rustc-demangle"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "rutie"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "ryu"
@@ -222,7 +213,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum regex 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "322cf97724bea3ee221b78fe25ac9c46114ebb51747ad5babd51a2fc6a8235a8"
 "checksum regex-syntax 0.6.16 (registry+https://github.com/rust-lang/crates.io-index)" = "1132f845907680735a84409c3bebc64d1364a5683ffbce899550cd09d5eaefc1"
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
-"checksum rutie 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "99a4174504679e66c524ffd839767eeca900d8c2e332ecf8bc6b9f15a5b8e5b1"
 "checksum ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c92464b447c0ee8c4fb3824ecc8383b81717b9f1e74ba2e72540aef7b9f82997"
 "checksum serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)" = "d46b3dfedb19360a74316866cef04687cd4d6a70df8e6a506c63512790769b72"
 "checksum serde_derive 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)" = "c22a0820adfe2f257b098714323563dd06426502abbbce4f51b72ef544c5027f"

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -19,8 +19,3 @@ libc = "0.2.68"
 [lib]
 name = "rubyfmt"
 crate-type = ["staticlib"]
-
-[build]
-rustflags = [
-  "-C", "link-args=-Wl,-undefined,dynamic_lookup"
-]

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -14,6 +14,7 @@ lazy_static = "1.3.0"
 bytecount = "0.6.0"
 backtrace = "0.3.45"
 jemallocator = { version = "0.3.0", features = ["disable_initial_exec_tls"] }
+rutie = "*"
 
 [lib]
 name = "rubyfmt"

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -14,8 +14,13 @@ lazy_static = "1.3.0"
 bytecount = "0.6.0"
 backtrace = "0.3.45"
 jemallocator = { version = "0.3.0", features = ["disable_initial_exec_tls"] }
-rutie = "*"
+libc = "0.2.68"
 
 [lib]
 name = "rubyfmt"
 crate-type = ["staticlib"]
+
+[build]
+rustflags = [
+  "-C", "link-args=-Wl,-undefined,dynamic_lookup"
+]

--- a/native/src/de.rs
+++ b/native/src/de.rs
@@ -1,0 +1,101 @@
+use rutie::rubysys::array::*;
+use rutie::rubysys::value::*;
+use serde::de::{*, Error as _};
+use rutie::rubysys::fixnum::*;
+
+pub fn from_value<T: DeserializeOwned>(v: Value) -> Result<T> {
+    T::deserialize(Deserializer(v))
+}
+
+struct Deserializer(Value);
+
+type Result<T> = std::result::Result<T, serde::de::value::Error>;
+type Error = serde::de::value::Error;
+
+impl<'de> serde::Deserializer<'de> for Deserializer {
+    type Error = Error;
+
+    fn deserialize_any<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
+        match self.0.ty() {
+            ValueType::Symbol => visitor.visit_borrowed_str(sym_to_str(self.0)?),
+            ValueType::RString => visitor.visit_borrowed_str(rstring_to_str(self.0)?),
+            ValueType::Array => visitor.visit_seq(SeqAccess::new(self.0)),
+            ValueType::Nil => visitor.visit_none(),
+            ValueType::True => visitor.visit_bool(true),
+            ValueType::False => visitor.visit_bool(false),
+            ValueType::Fixnum => visitor.visit_i64(unsafe { rb_num2ll(self.0) }),
+            other => {
+                Err(serde::de::Error::custom(format_args!("Unexpected type {:?}", other)))
+            }
+        }
+    }
+
+    serde::forward_to_deserialize_any! {
+        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
+        bytes byte_buf option unit unit_struct newtype_struct seq tuple
+        tuple_struct map struct enum identifier ignored_any
+    }
+}
+
+struct SeqAccess {
+    arr: Value,
+    idx: usize,
+    len: usize,
+}
+
+impl SeqAccess {
+    fn new(arr: Value) -> Self {
+        let len = unsafe { rb_ary_len(arr) } as usize;
+        Self { arr, len, idx: 0 }
+    }
+}
+
+impl<'de> serde::de::SeqAccess<'de> for SeqAccess {
+    type Error = Error;
+
+    fn next_element_seed<T: DeserializeSeed<'de>>(&mut self, seed: T) -> Result<Option<T::Value>> {
+        if self.idx < self.len {
+            let elem = unsafe { rb_ary_entry(self.arr, self.idx as _) };
+            self.idx += 1;
+            seed.deserialize(Deserializer(elem)).map(Some)
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn size_hint(&self) -> Option<usize> {
+        Some(self.len - self.idx)
+    }
+}
+
+fn sym_to_str(v: Value) -> Result<&'static str> {
+    use rutie::rubysys::symbol::*;
+    use std::ffi::CStr;
+
+    unsafe {
+        let id = rb_sym2id(v);
+        let c_str = CStr::from_ptr(rb_id2name(id));
+        c_str.to_str()
+            .map_err(|_| invalid_utf8(c_str.to_bytes()))
+    }
+}
+
+fn rstring_to_str(v: Value) -> Result<&'static str> {
+    use rutie::rubysys::string::*;
+
+    unsafe {
+        let bytes = std::slice::from_raw_parts(
+            rstring_ptr(v) as _,
+            rstring_len(v) as _,
+        );
+        std::str::from_utf8(bytes)
+            .map_err(|_| invalid_utf8(bytes))
+    }
+}
+
+fn invalid_utf8(bytes: &[u8]) -> Error {
+    Error::invalid_value(
+        Unexpected::Bytes(bytes),
+        &"a valid UTF-8 string",
+    )
+}

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -11,7 +11,6 @@ extern crate serde_json;
 use std::fs::File;
 use std::io::{self, BufReader, Write};
 use std::str;
-use crate::ruby::*;
 
 #[global_allocator]
 static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
@@ -37,6 +36,7 @@ mod types;
 use file_comments::FileComments;
 use parser_state::ParserState;
 use ruby_string_pointer::RubyStringPointer;
+use ruby::VALUE;
 
 type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error>>;
 
@@ -98,8 +98,8 @@ fn raise_if_error(value: Result) {
             // If the string contains nul, just display the error leading up to
             // the nul bytes
             let c_string = CString::from_vec_unchecked(e.to_string().into_bytes());
-            rb_raise(
-                rb_eRuntimeError,
+            ruby::rb_raise(
+                ruby::rb_eRuntimeError,
                 c_string.as_ptr(),
             );
         }

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -11,6 +11,7 @@ extern crate serde_json;
 use std::fs::File;
 use std::io::{self, BufReader, Write};
 use std::str;
+use rutie::rubysys::value::Value;
 
 #[global_allocator]
 static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
@@ -19,6 +20,7 @@ pub type RawStatus = i64;
 
 mod breakable_entry;
 mod comment_block;
+mod de;
 mod delimiters;
 mod file_comments;
 mod format;
@@ -35,66 +37,79 @@ use file_comments::FileComments;
 use parser_state::ParserState;
 use ruby_string_pointer::RubyStringPointer;
 
-enum Status {
-    Ok = 0,
-    BadFileName,
-    CouldntCreatefile,
-    BadJson,
-    CouldntWriteFile,
-}
+type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error>>;
 
 #[no_mangle]
 pub extern "C" fn format_sexp_tree_to_stdout(
+    runtime_error: Value,
     buf: RubyStringPointer,
-    tree: RubyStringPointer,
-) -> RawStatus {
-    raw_format_program(io::stdout(), buf, tree)
+    tree: Value,
+) {
+    raise_if_error(
+        runtime_error,
+        raw_format_program(None, buf, tree),
+    )
 }
 
 #[no_mangle]
 pub extern "C" fn format_sexp_tree_to_file(
+    runtime_error: Value,
     filename: RubyStringPointer,
     buf: RubyStringPointer,
-    tree: RubyStringPointer,
-) -> RawStatus {
-    let b = filename.into_buf();
-    let filename = match str::from_utf8(b) {
-        Ok(x) => x,
-        Err(_) => return Status::BadFileName as RawStatus,
-    };
-
-    let fp = match File::create(filename) {
-        Ok(x) => x,
-        Err(_) => return Status::CouldntCreatefile as RawStatus,
-    };
-
-    raw_format_program(fp, buf, tree)
+    tree: Value,
+) {
+    raise_if_error(
+        runtime_error,
+        raw_format_program(Some(filename), buf, tree),
+    )
 }
 
-fn raw_format_program<T: Write>(
-    writer: T,
+fn raw_format_program(
+    filename: Option<RubyStringPointer>,
     buf: RubyStringPointer,
-    tree: RubyStringPointer,
-) -> RawStatus {
+    tree: Value,
+) -> Result {
     let buf = buf.into_buf();
-    let tree = tree.into_buf();
-
-    let res = match toplevel_format_program(writer, buf, tree) {
-        Ok(()) => Status::Ok,
-        Err(status) => status,
+    let mut file;
+    let mut stdout = io::stdout();
+    let writer: &mut dyn Write = match filename {
+        Some(fp) => {
+            // FIXME: We should try to do an OsStr here
+            let name = str::from_utf8(fp.into_buf())?;
+            file = File::create(name)?;
+            &mut file
+        },
+        None => &mut stdout,
     };
 
-    res as RawStatus
+    toplevel_format_program(writer, buf, tree)
 }
 
-fn toplevel_format_program<W: Write>(mut writer: W, buf: &[u8], tree: &[u8]) -> Result<(), Status> {
+fn toplevel_format_program<W: Write>(mut writer: W, buf: &[u8], tree: Value) -> Result {
     let line_metadata = FileComments::from_buf(BufReader::new(buf))
         .expect("failed to load line metadata from memory");
     let mut ps = ParserState::new(line_metadata);
-    let v: ripper_tree_types::Program =
-        serde_json::from_slice(tree).map_err(|_| Status::BadJson)?;
+    let v: ripper_tree_types::Program = de::from_value(tree)?;
 
     format::format_program(&mut ps, v);
 
-    ps.write(&mut writer).map_err(|_| Status::CouldntWriteFile)
+    ps.write(&mut writer)?;
+    Ok(())
+}
+
+fn raise_if_error(runtime_error: Value, value: Result) {
+    use rutie::rubysys::vm::rb_raise;
+    use std::ffi::CString;
+
+    if let Err(e) = value {
+        unsafe {
+            // If the string contains nul, just display the error leading up to
+            // the nul bytes
+            let c_string = CString::from_vec_unchecked(e.to_string().into_bytes());
+            rb_raise(
+                runtime_error,
+                c_string.as_ptr(),
+            );
+        }
+    }
 }

--- a/native/src/ruby.rs
+++ b/native/src/ruby.rs
@@ -1,0 +1,63 @@
+#![allow(non_camel_case_types, dead_code)]
+
+#[derive(Clone, Copy)]
+#[repr(transparent)]
+pub struct VALUE(libc::uintptr_t);
+
+#[derive(Clone, Copy)]
+#[repr(transparent)]
+pub struct ID(libc::uintptr_t);
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub enum ruby_value_type {
+    RUBY_T_NONE   = 0x00,
+
+    RUBY_T_OBJECT = 0x01,
+    RUBY_T_CLASS  = 0x02,
+    RUBY_T_MODULE = 0x03,
+    RUBY_T_FLOAT  = 0x04,
+    RUBY_T_STRING = 0x05,
+    RUBY_T_REGEXP = 0x06,
+    RUBY_T_ARRAY  = 0x07,
+    RUBY_T_HASH   = 0x08,
+    RUBY_T_STRUCT = 0x09,
+    RUBY_T_BIGNUM = 0x0a,
+    RUBY_T_FILE   = 0x0b,
+    RUBY_T_DATA   = 0x0c,
+    RUBY_T_MATCH  = 0x0d,
+    RUBY_T_COMPLEX  = 0x0e,
+    RUBY_T_RATIONAL = 0x0f,
+
+    RUBY_T_NIL    = 0x11,
+    RUBY_T_TRUE   = 0x12,
+    RUBY_T_FALSE  = 0x13,
+    RUBY_T_SYMBOL = 0x14,
+    RUBY_T_FIXNUM = 0x15,
+    RUBY_T_UNDEF  = 0x16,
+
+    RUBY_T_IMEMO  = 0x1a,
+    RUBY_T_NODE   = 0x1b,
+    RUBY_T_ICLASS = 0x1c,
+    RUBY_T_ZOMBIE = 0x1d,
+
+    RUBY_T_MASK   = 0x1f
+}
+
+extern "C" {
+    // Macros/inline functions wrapped as real functions
+    pub fn rubyfmt_rstring_ptr(v: VALUE) -> *const libc::c_char;
+    pub fn rubyfmt_rstring_len(v: VALUE) -> libc::c_long;
+    pub fn rubyfmt_rb_type(v: VALUE) -> ruby_value_type;
+    pub fn rubyfmt_rb_num2ll(v: VALUE) -> libc::c_longlong;
+    pub fn rubyfmt_rb_ary_len(arr: VALUE) -> libc::c_long;
+
+    // C statics
+    pub static rb_eRuntimeError: VALUE;
+
+    // C functions
+    pub fn rb_sym2id(sym: VALUE) -> ID;
+    pub fn rb_id2name(id: ID) -> *const libc::c_char;
+    pub fn rb_ary_entry(arr: VALUE, idx: libc::c_long) -> VALUE;
+    pub fn rb_raise(cls: VALUE, msg: *const libc::c_char);
+}

--- a/rubyfmt.rb
+++ b/rubyfmt.rb
@@ -205,9 +205,9 @@ class Parser < Ripper::SexpBuilderPP
   end
 end
 
+GC.disable
 file_data = File.read(ARGV[0])
 parsed = Parser.new(file_data).parse
-inspected_parsed = JSON.dump(parsed)
 STDERR.puts(parsed.inspect) unless ENV["RUBYFMT_USE_RELEASE"]
-Rubyfmt::format_to_stdout(file_data, inspected_parsed)
+Rubyfmt::format_to_stdout(file_data, parsed)
 STDOUT.close


### PR DESCRIPTION
This removes the json serialization/parsing in favor of linking libruby
directly, and inspecting the ruby objects directly. This is done by just
implementing a minimal `serde::Deserializer` that traverses the Ruby
objects. While this does *not* speed up the creation of the AST, it does
remove the call to `.to_json`, which could be as much as 15% of the
total runtime.

In order to do this, we need to call libruby functions directly. There
are two main libraries for this, Rutie and Helix. Both of these are DSLs
for writing Ruby classes/modules in Rust. Since using those DSLs would
be a bigger change, I opted to just look at their respective bindings to
libruby.

If there is a hard part of using Rust from Ruby, it's that many of
Ruby's important functions (like getting the pointer for a string) are
exposed as macros or inline functions, rather than symbols which can be
linked against.

libcruby-sys (from Helix) takes the same approach as this PR,
wrapping anything that is a macro in a small C function compiled as part
of a gem. The problem is that libcruby-sys then requires that gem as a
dependency of the consumer (`helix_runtime`). Since we're disabling gems,
that's a non-starter. This function wrapping does technically have some
small runtime cost (if it doesn't get inlined by LTO. I'm not familiar
enough with how C compilation for Ruby gems works to know if LTO is
happening or not), but the difference was not measurable on my machine.

Rutie avoids this by re-implementing those macros in Rust. By definition
anything in those macros has to be in `ruby.h`, so it's technically
public, but it's unclear how stable any of that is. For example, getting
the length of a string involves checking if it's embedded (a.k.a the
short string optimization). While the things that it's coupled to seem
to have historically been relatively stable, it makes me uncomfortable
enough to justify what we're doing.

I originally used Rutie, but eventually switched to linking up to
libruby ourselves. If we're fine with what Rutie is doing, that change
is done as a separate commit so it can be reverted.

In addition to the main change in this PR, while I was debugging this
impl, I wanted to see the full error message. I've changed this to raise
the actual error instead of returning an opaque status code.

I've also disabled GC for an additional small win. The end result of all
this is that on my machine, formatting
rspec-core/lib/rspec/core/configuration.rb goes from ~98ms to ~80ms. At
this point any additional optimization will hit serious diminishing
returns. We're spending less than 40% our time in Rust, the majority is
spent in Ruby setup/teardown, `require`, and the actual parsing.

That said, of the time spent in our code, 60% of that is in the
deserialization. Some of that might just be the inherent cost of
constructing all these data structures, but I suspect that serde is
generating less than optimal code for `#[serde(untagged)]`, so I plan on
digging into this further. The other big win could come from not freeing
all the memory we allocate for the AST. However, since it's passed by
value everywhere instead of by reference, this is non-trivial. I suspect
that if we pass by reference everywhere we might see a pretty decent win
anyway, so I'll explore that as well.
