### PR TITLE
Refactor mlhs handling

### DIFF
--- a/native/src/format.rs
+++ b/native/src/format.rs
@@ -236,8 +236,13 @@ pub fn format_mlhs(ps: &mut ParserState, mlhs: MLhs) {
     ps.emit_open_paren();
 
     ps.with_start_of_line(false, |ps| {
-        let len = (mlhs.0).len();
-        for (idx, inner) in (mlhs.0).into_iter().enumerate() {
+        let mut first = true;
+        for inner in mlhs.0 {
+            if !first {
+                ps.emit_comma_space();
+            }
+            first = false;
+
             match inner {
                 MLhsInner::Field(f) => format_field(ps, f),
                 MLhsInner::Ident(i) => format_ident(ps, i),
@@ -246,9 +251,6 @@ pub fn format_mlhs(ps: &mut ParserState, mlhs: MLhs) {
                 }
                 MLhsInner::VarField(vf) => format_var_field(ps, vf),
                 MLhsInner::MLhs(mlhs) => format_mlhs(ps, *mlhs),
-            }
-            if idx != len - 1 {
-                ps.emit_comma_space();
             }
         }
     });


### PR DESCRIPTION
Rather than manually parsing the tag, and losing the debug logging that
occurs for most tags, we re-use the tag parsing from the `def_tag!` macro.
I've also cleaned up the loop in formatting

<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->
