### PR TITLE
`#[derive(Deserialize)]` for `MRHSNewFromArgs`

### DIFF
--- a/native/src/ripper_tree_types.rs
+++ b/native/src/ripper_tree_types.rs
@@ -267,102 +267,16 @@ pub enum MRHSNewFromArgsOrEmpty {
     Empty(Vec<Expression>),
 }
 
-// MRHSNewFromArgs is really annoying to parse, consider:
-//
-// ```ruby
-// begin
-// rescue A,*B
-// end
-// ```
-// this will parse as:
-//
-// [:program,
-//  [[:begin,
-//    [:bodystmt,
-//     [[:void_stmt]],
-//     [:rescue,
-//      [:mrhs_add_star,
-//       [:mrhs_new_from_args, [[:var_ref, [:@const, "A", [1, 13]]]]],
-//       [:var_ref, [:@const, "B", [1, 16]]]],
-//      nil,
-//      [[:void_stmt]],
-//      nil],
-//     nil,
-//     nil]]]]
-//
-// however, if you have
-// ```ruby
-// a,b = 1,2
-// ```
-// you get
-// [:program,
-// [[:massign,
-//   [[:var_field, [:@ident, "a", [1, 0]]],
-//    [:var_field, [:@ident, "b", [1, 2]]]],
-//   [:mrhs_new_from_args, [[:@int, "1", [1, 4]]], [:@int, "2", [1, 6]]]]]]
-//
-// in the first case, the mrhs_new_from_args looks like:
-// [:mrhs_new_from_args, Vec<Expression>]
-// in the second case, the mrhs_new_from_args_tag looks like:
-// [:mrhs_new_from_args, Vec<Expression>, Expression]
-//
-// so we need to implement a custom deserializer, I am sad
 def_tag!(mrhs_new_from_args_tag, "mrhs_new_from_args");
-#[derive(Debug, Clone)]
+#[derive(Deserialize, Debug, Clone)]
 pub struct MRHSNewFromArgs(
     pub mrhs_new_from_args_tag,
     pub ArgsAddStarOrExpressionList,
+    #[serde(default)]
+    /// This will be none if only two expressions are given and the last is a
+    /// splat. For example, `rescue A, *B`
     pub Option<Box<Expression>>,
 );
-
-impl<'de> Deserialize<'de> for MRHSNewFromArgs {
-    fn deserialize<D>(deserializer: D) -> Result<MRHSNewFromArgs, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        struct MRHSNewFromArgsVisitor;
-
-        impl<'de> de::Visitor<'de> for MRHSNewFromArgsVisitor {
-            type Value = MRHSNewFromArgs;
-
-            fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
-                write!(f, "[mrhs_new_from_args, Vec<Expression>(, Expression?)]")
-            }
-
-            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
-            where
-                A: de::SeqAccess<'de>,
-            {
-                let tag: &str = match seq.next_element() {
-                    Ok(Some(s)) => s,
-                    _ => {
-                        return Err(de::Error::custom("didn't get right tag"));
-                    }
-                };
-                if tag != "mrhs_new_from_args" {
-                    return Err(de::Error::custom("didn't get right tag"));
-                }
-
-                let expressions: ArgsAddStarOrExpressionList = seq
-                    .next_element()?
-                    .expect("didn't get args add star or expression list in mrhs new");
-                let tail_expression: Option<Box<Expression>> = match seq.next_element() {
-                    Ok(Some(v)) => Some(Box::new(v)),
-                    Ok(None) => None,
-                    Err(e) => None,
-                };
-
-                Ok(MRHSNewFromArgs(
-                    mrhs_new_from_args_tag,
-                    expressions,
-                    tail_expression,
-                ))
-            }
-        }
-
-        deserializer.deserialize_seq(MRHSNewFromArgsVisitor)
-    }
-}
 
 def_tag!(rescue_mod_tag, "rescue_mod");
 #[derive(Deserialize, Debug, Clone)]


### PR DESCRIPTION
There's no reason this struct needs a custom deserializer. We just need
to tell Serde to use `Default::default` if the field isn't present.

<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->
