### PR TITLE
Refactor `StringLiteral` deserialization

### DIFF
--- a/native/src/format.rs
+++ b/native/src/format.rs
@@ -1068,13 +1068,11 @@ pub fn format_heredoc_string_literal(
 }
 
 pub fn format_string_literal(ps: &mut ParserState, sl: StringLiteral) {
-    let parts = (sl.2).1;
-    // some(hd) if we have a heredoc
-    match sl.1 {
-        Some(hd) => {
-            format_heredoc_string_literal(ps, hd, parts);
+    match sl {
+        StringLiteral::Heredoc(_, hd, StringContent(_, parts)) => {
+            format_heredoc_string_literal(ps, hd, parts)
         }
-        None => {
+        StringLiteral::Normal(_, StringContent(_, parts)) => {
             if ps.at_start_of_line() {
                 ps.emit_indent();
             }

--- a/native/src/ripper_tree_types.rs
+++ b/native/src/ripper_tree_types.rs
@@ -512,67 +512,10 @@ def_tag!(heredoc_string_literal_tag, "heredoc_string_literal");
 pub struct HeredocStringLiteral(pub heredoc_string_literal_tag, pub (String, String));
 
 def_tag!(string_literal_tag, "string_literal");
-#[derive(Debug, Clone)]
-pub struct StringLiteral(
-    pub string_literal_tag,
-    pub Option<HeredocStringLiteral>,
-    pub StringContent,
-);
-
-impl<'de> Deserialize<'de> for StringLiteral {
-    fn deserialize<D>(deserializer: D) -> Result<StringLiteral, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        struct StringLiteralVisitor;
-
-        #[derive(RipperDeserialize, Debug, Clone)]
-        enum HeredocOrStringContent {
-            Heredoc(HeredocStringLiteral),
-            StringContent(StringContent),
-        };
-
-        impl<'de> de::Visitor<'de> for StringLiteralVisitor {
-            type Value = StringLiteral;
-
-            fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
-                write!(f, "[string_literal, [heredoc]?, string_content]")
-            }
-
-            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
-            where
-                A: de::SeqAccess<'de>,
-            {
-                let tag: &str = match seq.next_element()? {
-                    Some(x) => x,
-                    None => return Err(de::Error::custom("got no tag")),
-                };
-
-                if tag != "string_literal" {
-                    return Err(de::Error::custom("didn't get right tag"));
-                }
-
-                let mut h_or_sc: Option<HeredocOrStringContent> = seq.next_element()?;
-                let h_or_sc =
-                    h_or_sc.expect("didn't get either string content or heredoc in string literal");
-
-                let sl = match h_or_sc {
-                    HeredocOrStringContent::Heredoc(hd) => {
-                        let sc: Option<StringContent> = seq.next_element()?;
-                        let sc = sc.expect("didn't get string content in heredoc");
-                        StringLiteral(string_literal_tag, Some(hd), sc)
-                    }
-                    HeredocOrStringContent::StringContent(sc) => {
-                        StringLiteral(string_literal_tag, None, sc)
-                    }
-                };
-
-                Ok(sl)
-            }
-        }
-
-        deserializer.deserialize_seq(StringLiteralVisitor)
-    }
+#[derive(RipperDeserialize, Debug, Clone)]
+pub enum StringLiteral {
+    Normal(string_literal_tag, StringContent),
+    Heredoc(string_literal_tag, HeredocStringLiteral, StringContent),
 }
 
 def_tag!(xstring_literal_tag, "xstring_literal");
@@ -587,13 +530,11 @@ impl DynaSymbol {
     pub fn to_string_literal(self) -> StringLiteral {
         match self.1 {
             StringContentOrStringContentParts::StringContent(sc) => {
-                StringLiteral(string_literal_tag, None, sc)
+                StringLiteral::Normal(string_literal_tag, sc)
             }
-            StringContentOrStringContentParts::StringContentParts(scp) => StringLiteral(
-                string_literal_tag,
-                None,
-                StringContent(string_content_tag, scp),
-            ),
+            StringContentOrStringContentParts::StringContentParts(scp) => {
+                StringLiteral::Normal(string_literal_tag, StringContent(string_content_tag, scp))
+            }
         }
     }
 }


### PR DESCRIPTION
It seems worth it to know if we've got a normal or a heredoc string
literal in the structure itself, rather than encoding that as one field
being `None`. If we do this we can deserialize it the same way we do
untagged enums (doing this required adding multiple field support to our
custom deserialize, which was fairly simple)

It might even be worth having a `NormalStringLiteral` and
`HeredocStringLiteral` (the latter containing the contents as well as
what's currently in a struct with that name), but doing that will
require adding `#[serde(flatten)]` support to tuple structs in Serde

<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->
