### PR TITLE
Refactor `Deserialize` for `ArgsAddStar`

### DIFF
--- a/native/src/ripper_tree_types.rs
+++ b/native/src/ripper_tree_types.rs
@@ -577,34 +577,15 @@ impl<'de> Deserialize<'de> for ArgsAddStar {
             where
                 A: de::SeqAccess<'de>,
             {
-                let tag: &str = match seq.next_element()? {
-                    Some(x) => x,
-                    None => return Err(de::Error::custom("got no tag")),
-                };
-
-                if tag != "args_add_star" {
-                    return Err(de::Error::custom("didn't get right tag"));
-                }
-
-                let left_expressions: ArgsAddStarOrExpressionList = seq
-                    .next_element()?
-                    .ok_or_else(|| de::Error::custom("didn't get array of expressions"))?;
-
-                let star_expression: Expression = seq
-                    .next_element()?
-                    .ok_or_else(|| de::Error::custom("didn't get single star expression"))?;
-
-                let mut right_expressions = vec![];
-                let mut next_expression: Option<Expression> = seq.next_element()?;
-                while next_expression.is_some() {
-                    right_expressions.push(next_expression.expect("we checked it's some"));
-                    next_expression = seq.next_element()?;
-                }
+                let (tag, left_expressions, star_expression) =
+                    Deserialize::deserialize(de::value::SeqAccessDeserializer::new(&mut seq))?;
+                let right_expressions =
+                    Deserialize::deserialize(de::value::SeqAccessDeserializer::new(&mut seq))?;
 
                 Ok(ArgsAddStar(
-                    args_add_star_tag,
-                    Box::new(left_expressions),
-                    Box::new(star_expression),
+                    tag,
+                    left_expressions,
+                    star_expression,
                     right_expressions,
                 ))
             }


### PR DESCRIPTION
If we add support for `#[serde(flatten)]` on tuple structs to Serde, we
can derive Deserialize for this struct.

<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->
