### PR TITLE
Re-enable warnings in ripper_tree_types.rs, fix them

### DIFF
--- a/native/src/format.rs
+++ b/native/src/format.rs
@@ -29,7 +29,7 @@ pub fn format_def(ps: &mut ParserState, def: Def) {
     ps.emit_newline();
 }
 
-pub fn inner_format_params(ps: &mut ParserState, params: Params) {
+pub fn inner_format_params(ps: &mut ParserState, params: Box<Params>) {
     let non_null_positions = params.non_null_positions();
     //def foo(a, b=nil, *args, d, e:, **kwargs, &blk)
     //        ^  ^___^  ^___^  ^  ^    ^_____^   ^
@@ -118,7 +118,7 @@ pub fn format_blockvar(ps: &mut ParserState, bv: BlockVar) {
     });
 }
 
-pub fn format_params(ps: &mut ParserState, params: Params, delims: BreakableDelims) {
+pub fn format_params(ps: &mut ParserState, params: Box<Params>, delims: BreakableDelims) {
     let have_any_params = params.non_null_positions().iter().any(|&x| x);
     if !have_any_params {
         return;
@@ -289,7 +289,7 @@ pub fn emit_params_separator(ps: &mut ParserState, index: usize, length: usize) 
     }
 }
 
-pub fn format_bodystmt(ps: &mut ParserState, bodystmt: BodyStmt) {
+pub fn format_bodystmt(ps: &mut ParserState, bodystmt: Box<BodyStmt>) {
     let expressions = bodystmt.1;
     let rescue_part = bodystmt.2;
     let else_part = bodystmt.3;
@@ -1868,7 +1868,7 @@ pub fn format_backref(ps: &mut ParserState, backref: Backref) {
     }
 }
 
-pub fn format_method_add_block(ps: &mut ParserState, mab: MethodAddBlock) {
+pub fn format_method_add_block(ps: &mut ParserState, mab: Box<MethodAddBlock>) {
     if ps.at_start_of_line() {
         ps.emit_indent();
     }

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -1,12 +1,6 @@
 #![deny(warnings, missing_copy_implementations)]
 #[macro_use]
 extern crate lazy_static;
-extern crate backtrace;
-extern crate regex;
-
-extern crate bytecount;
-extern crate serde;
-extern crate serde_json;
 
 use std::fs::File;
 use std::io::{self, BufReader, Write};
@@ -42,7 +36,7 @@ type Result<T = ()> = std::result::Result<T, Box<dyn std::error::Error>>;
 
 #[no_mangle]
 pub extern "C" fn format_sexp_tree_to_stdout(buf: RubyStringPointer, tree: VALUE) {
-    raise_if_error(raw_format_program(None, buf, tree))
+    raise_if_error(raw_format_program(None, buf, tree));
 }
 
 #[no_mangle]


### PR DESCRIPTION
This removes the `#![allow(warnings)]` from that file, and fixes (or
allows) all the warnings that occurred. The most notable were several
cases of `clippy::large_enum_variant`, which triggers when an enum
variant is more than 200 bytes larger than the next largest. This
triggered quite a bit because Expression was 864 bytes! Note that I
generally didn't follow the advice of the lint, and generally opted to
make the structs that were the cause smaller. Expression is now 184
bytes. This was a marginal improvement in CPU time, and a significant
improvement in memory usage.

<!--
Hi there! Thanks for taking the time to file  a pull request against Rubyfmt
Right now we're accepting CLI ergonomics PRs, Editor Integration PRs, and bug
fixes only. We define bugs as Rubyfmt failing to format a file, or formatting a
file such that it's behaviour changes. If you're trying to change the behaviour
of the formatter, or style the output, please don't file the PR. We're working
on getting that just right, and will accept those in a future release.
-->
