### PR TITLE
Add option to specify path to rubyfmt.rb in vim plugin

### DIFF
--- a/rubyfmt.vim
+++ b/rubyfmt.vim
@@ -1,8 +1,10 @@
 let s:cpo_save = &cpo
 set cpo&vim
 
+let g:rubyfmt_path = '/Users/penelope/dev/rubyfmt/rubyfmt.rb'
+
 function! rubyfmt#format() abort
-  let l:bin_args = ['RUBYFMT_USE_RELEASE=1', 'ruby', '--disable=all', '/Users/penelope/dev/rubyfmt/rubyfmt.rb', '-i']
+  let l:bin_args = ['RUBYFMT_USE_RELEASE=1', 'ruby', '--disable=all', g:rubyfmt_path, '-i']
   let l:curw = winsaveview()
   let l:tmpname = "/tmp/bees.rb"
   call writefile(rubyfmt#get_lines(), l:tmpname)


### PR DESCRIPTION
Lets one specify the path to `rubyfmt.rb` in vim.

```vim
" in $MYVIMRC
source /Users/mikker/dev/rubyfmt/rubyfmt.vim
let g:rubyfmt_path = '/Users/mikker/dev/rubyfmt/rubyfmt.rb'
```

It's so exciting, @penelopezone – it's working great!